### PR TITLE
Admin access to view active sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: redis:7-alpine
     container_name: user-management-service-redis
     ports:
-      - "6379:6379"
+      - ${REDIS_PORT}:${REDIS_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: user-management-service-redis
+    ports:
+      - "6379:6379"

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,19 @@
 			<version>2.5.0</version>
 		</dependency>
 
+<!--		testing dependency-->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,18 @@
 			<artifactId>spring-session-data-redis</artifactId>
 		</dependency>
 
-		<!-- MapStruct for dto -->
+<!--		MapStruct for dto-->
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>1.5.5.Final</version> <!-- or latest stable -->
+		</dependency>
+
+<!--		Swagger doc-->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,15 @@
             <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
+<!--		redis session-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-data-redis</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,13 @@
 			<artifactId>spring-session-data-redis</artifactId>
 		</dependency>
 
+		<!-- MapStruct for dto -->
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version> <!-- or latest stable -->
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -118,6 +125,11 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
@@ -136,8 +148,6 @@
 			</plugin>
 		</plugins>
 	</build>
-
-
 
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/talentradar/user_service/config/SecurityConfig.java
+++ b/src/main/java/com/talentradar/user_service/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui.html",
+                                "/swagger-ui/**","/api/v1/admin/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/**")
                         .permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/com/talentradar/user_service/config/SwaggerConfig.java
+++ b/src/main/java/com/talentradar/user_service/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.talentradar.user_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("User Management API")
+                        .version("1.0")
+                        .description("This is the API documentation for User management service Spring Boot App"));
+    }
+}

--- a/src/main/java/com/talentradar/user_service/controller/SessionController.java
+++ b/src/main/java/com/talentradar/user_service/controller/SessionController.java
@@ -1,7 +1,9 @@
 package com.talentradar.user_service.controller;
 
 import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.exception.UnauthorizedException;
 import com.talentradar.user_service.service.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +19,11 @@ public class SessionController {
     private final SessionService sessionService;
 
     @GetMapping(name = "fetchActiveSessions", path = "/sessions")
-    public ResponseEntity<Page<SessionResponseDto>> viewProjects(Pageable pageable){
+    public ResponseEntity<Page<SessionResponseDto>> viewProjects(HttpServletRequest request, Pageable pageable){
+        String userRole = request.getHeader("X-User-Role");
+        if (userRole == null || !userRole.equalsIgnoreCase("ADMIN")) {
+            throw new UnauthorizedException("Only admin has access to this data!");
+        }
         Page<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);
         return ResponseEntity.ok(sessionsList);
     }

--- a/src/main/java/com/talentradar/user_service/controller/SessionController.java
+++ b/src/main/java/com/talentradar/user_service/controller/SessionController.java
@@ -2,9 +2,14 @@ package com.talentradar.user_service.controller;
 
 import com.talentradar.user_service.dto.SessionResponseDto;
 import com.talentradar.user_service.exception.UnauthorizedException;
+import com.talentradar.user_service.listener.AuthenticationSuccessListener;
 import com.talentradar.user_service.service.SessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/admin")
 @RequiredArgsConstructor
+@Tag(name = "Session Controller", description = "Manage all user's session api")
 public class SessionController {
+    private static final Logger logger = LoggerFactory.getLogger(SessionController.class);
     private final SessionService sessionService;
 
     @GetMapping(name = "fetchActiveSessions", path = "/sessions")
+    @Operation(summary = "Fetch all active session",
+            description = "This end point allow only admin to view all of the active session")
     public ResponseEntity<Page<SessionResponseDto>> viewProjects(HttpServletRequest request, Pageable pageable){
         String userRole = request.getHeader("X-User-Role");
         if (userRole == null || !userRole.equalsIgnoreCase("ADMIN")) {
+            logger.info("Unauthorized user tried to access session data");
             throw new UnauthorizedException("Only admin has access to this data!");
         }
         Page<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);

--- a/src/main/java/com/talentradar/user_service/controller/SessionController.java
+++ b/src/main/java/com/talentradar/user_service/controller/SessionController.java
@@ -1,0 +1,24 @@
+package com.talentradar.user_service.controller;
+
+import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class SessionController {
+    private final SessionService sessionService;
+
+    @GetMapping(name = "fetchActiveSessions", path = "/sessions")
+    public ResponseEntity<Page<SessionResponseDto>> viewProjects(Pageable pageable){
+        Page<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);
+        return ResponseEntity.ok(sessionsList);
+    }
+}

--- a/src/main/java/com/talentradar/user_service/dto/SessionResponseDto.java
+++ b/src/main/java/com/talentradar/user_service/dto/SessionResponseDto.java
@@ -1,0 +1,18 @@
+package com.talentradar.user_service.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+public class SessionResponseDto {
+    private UUID id;
+    private String sessionId;
+    private String ipAddress;
+    private String deviceInfo;
+    private LocalDateTime createdAt;
+    private boolean isActive;
+
+    private UserSummaryDto user;
+}
+

--- a/src/main/java/com/talentradar/user_service/dto/UserSummaryDto.java
+++ b/src/main/java/com/talentradar/user_service/dto/UserSummaryDto.java
@@ -1,0 +1,17 @@
+package com.talentradar.user_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSummaryDto {
+    private UUID id;
+    private String fullName;
+    private String email;
+}
+

--- a/src/main/java/com/talentradar/user_service/exception/AppException.java
+++ b/src/main/java/com/talentradar/user_service/exception/AppException.java
@@ -1,0 +1,7 @@
+package com.talentradar.user_service.exception;
+
+public class AppException extends RuntimeException{
+    public AppException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -16,6 +17,7 @@ import com.talentradar.user_service.dto.LoginResponseDto;
 import org.springframework.web.context.request.WebRequest;
 
 @RestControllerAdvice
+@Hidden
 public class GlobalExceptionHandler {
     // Handle invalid credentials exception
     @ExceptionHandler(BadCredentialsException.class)

--- a/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.talentradar.user_service.exception;
 
+import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.talentradar.user_service.dto.LoginResponseDto;
+import org.springframework.web.context.request.WebRequest;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -23,5 +26,18 @@ public class GlobalExceptionHandler {
                 .errors(List.of(errorDetails))
                 .build();
         return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    // handle user is not found exception response
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<?> handleUserNotFound(
+            UserNotFoundException exception, WebRequest webRequest) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", HttpStatus.NOT_FOUND.value());
+        body.put("timestamp", LocalDateTime.now());
+        body.put("message", exception.getMessage());
+        body.put("path", webRequest.getContextPath());
+        body.put("sessionId", webRequest.getSessionId());
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/talentradar/user_service/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service.exception;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -39,5 +40,16 @@ public class GlobalExceptionHandler {
         body.put("path", webRequest.getContextPath());
         body.put("sessionId", webRequest.getSessionId());
         return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<?> handleUnauthorizedException
+            (UnauthorizedException unauthorizedException, WebRequest webRequest) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", HttpStatus.UNAUTHORIZED.value());
+        body.put("timestamp", LocalDateTime.now());
+        body.put("message", unauthorizedException.getMessage());
+        body.put("path", webRequest.getContextPath());
+        body.put("sessionId", webRequest.getSessionId());
+        return new ResponseEntity<>(body, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/talentradar/user_service/exception/UnauthorizedException.java
+++ b/src/main/java/com/talentradar/user_service/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.talentradar.user_service.exception;
+
+public class UnauthorizedException extends AppException{
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/talentradar/user_service/exception/UserNotFoundException.java
+++ b/src/main/java/com/talentradar/user_service/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.talentradar.user_service.exception;
+
+public class UserNotFoundException extends AppException{
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -3,7 +3,7 @@ package com.talentradar.user_service.listener;
 import com.talentradar.user_service.exception.UserNotFoundException;
 import com.talentradar.user_service.model.Session;
 import com.talentradar.user_service.model.User;
-import com.talentradar.user_service.repository.SessionRepository;
+import com.talentradar.user_service.repository.UserSessionRepository;
 import com.talentradar.user_service.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.ApplicationListener;
@@ -19,11 +19,11 @@ import java.time.LocalDateTime;
 @Component
 public class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
 
-    private final SessionRepository sessionRepository;
+    private final UserSessionRepository userSessionRepository;
     private final UserRepository userRepository;
 
-    public AuthenticationSuccessListener(SessionRepository sessionRepository, UserRepository userRepository) {
-        this.sessionRepository = sessionRepository;
+    public AuthenticationSuccessListener(UserSessionRepository userSessionRepository, UserRepository userRepository) {
+        this.userSessionRepository = userSessionRepository;
         this.userRepository = userRepository;
     }
 
@@ -54,7 +54,7 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
                 .isActive(true)
                 .build();
 
-        sessionRepository.save(session);
+        userSessionRepository.save(session);
     }
 }
 

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -6,10 +6,12 @@ import com.talentradar.user_service.model.User;
 import com.talentradar.user_service.repository.UserSessionRepository;
 import com.talentradar.user_service.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -18,16 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /* The class handles the event upon successful sign-in */
-@Component
+@Service
+@RequiredArgsConstructor
 public class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationSuccessListener.class);
     private final UserSessionRepository userSessionRepository;
     private final UserRepository userRepository;
-
-    public AuthenticationSuccessListener(UserSessionRepository userSessionRepository, UserRepository userRepository) {
-        this.userSessionRepository = userSessionRepository;
-        this.userRepository = userRepository;
-    }
 
     @Override
     public void onApplicationEvent(AuthenticationSuccessEvent event) {

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -1,0 +1,61 @@
+package com.talentradar.user_service.listener;
+
+import com.talentradar.user_service.exception.UserNotFoundException;
+import com.talentradar.user_service.model.Session;
+import com.talentradar.user_service.model.User;
+import com.talentradar.user_service.repository.SessionRepository;
+import com.talentradar.user_service.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.LocalDateTime;
+
+/* The class handles the event upon successful sign-in */
+@Component
+public class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
+
+    private final SessionRepository sessionRepository;
+    private final UserRepository userRepository;
+
+    public AuthenticationSuccessListener(SessionRepository sessionRepository, UserRepository userRepository) {
+        this.sessionRepository = sessionRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(AuthenticationSuccessEvent event) {
+        String email = ((UserDetails) event.getAuthentication().getPrincipal()).getUsername();
+        // check whether username exists
+        User user = this.userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException(
+                        String.format("A user with the email '%s' does not exist",
+                                email))
+                );
+
+        HttpServletRequest request = ((ServletRequestAttributes)
+                RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String ip = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+
+        String sessionId = request.getSession().getId();
+
+        Session session = Session.builder()
+                .sessionId(sessionId)
+                .id(user.getId())
+                .ipAddress(ip)
+                .deviceInfo(userAgent)
+                .loginTimestamp(LocalDateTime.now())
+                .isActive(true)
+                .build();
+
+        sessionRepository.save(session);
+    }
+}
+
+

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -50,7 +50,7 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
                 .id(user.getId())
                 .ipAddress(ip)
                 .deviceInfo(userAgent)
-                .loginTimestamp(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .isActive(true)
                 .build();
 

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -45,16 +45,29 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
 
         String sessionId = request.getSession().getId();
 
-        Session session = Session.builder()
-                .sessionId(sessionId)
-                .id(user.getId())
-                .ipAddress(ip)
-                .deviceInfo(userAgent)
-                .createdAt(LocalDateTime.now())
-                .isActive(true)
-                .build();
+        // Check if session with this sessionId already exists
+        Session existing = userSessionRepository.findBySessionId(sessionId).orElse(null);
 
-        userSessionRepository.save(session);
+        if (existing == null) {
+            // create new
+            Session session = Session.builder()
+                    .sessionId(sessionId)
+                    .user(user)
+                    .ipAddress(ip)
+                    .deviceInfo(userAgent)
+                    .createdAt(LocalDateTime.now())
+                    .isActive(true)
+                    .build();
+            userSessionRepository.save(session);
+        } else {
+            // update fields
+            existing.setIpAddress(ip);
+            existing.setDeviceInfo(userAgent);
+            existing.setActive(true);
+            existing.setCreatedAt(LocalDateTime.now());
+            userSessionRepository.save(existing);
+        }
+
     }
 }
 

--- a/src/main/java/com/talentradar/user_service/mapper/SessionMapper.java
+++ b/src/main/java/com/talentradar/user_service/mapper/SessionMapper.java
@@ -1,0 +1,20 @@
+package com.talentradar.user_service.mapper;
+
+import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.model.Session;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface SessionMapper {
+
+    // map session + nested user info
+    @Mapping(source = "user.fullName", target = "user.fullName")
+    @Mapping(source = "user.email", target = "user.email")
+    SessionResponseDto toDto(Session session);
+
+    List<SessionResponseDto> toDtoList(List<Session> sessions);
+}
+

--- a/src/main/java/com/talentradar/user_service/model/Session.java
+++ b/src/main/java/com/talentradar/user_service/model/Session.java
@@ -23,7 +23,7 @@ public class Session {
     private String sessionId;
     private String ipAddress;
     private String deviceInfo;
-    private LocalDateTime loginTimestamp;
+    private LocalDateTime createdAt;
     private boolean isActive;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/talentradar/user_service/model/Session.java
+++ b/src/main/java/com/talentradar/user_service/model/Session.java
@@ -1,0 +1,32 @@
+package com.talentradar.user_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "sessions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Session {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String sessionId;
+    private String ipAddress;
+    private String deviceInfo;
+    private LocalDateTime loginTimestamp;
+    private boolean isActive;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // set foreign key
+    private User user;
+}

--- a/src/main/java/com/talentradar/user_service/model/User.java
+++ b/src/main/java/com/talentradar/user_service/model/User.java
@@ -1,18 +1,11 @@
 package com.talentradar.user_service.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,6 +43,9 @@ public class User {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Session> sessions = new ArrayList<>(); // each user can have many sessions
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/talentradar/user_service/repository/SessionRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/SessionRepository.java
@@ -1,0 +1,8 @@
+package com.talentradar.user_service.repository;
+
+import com.talentradar.user_service.model.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+    //TODO: retrieve or find sessions By userId and session is active
+}

--- a/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
@@ -3,6 +3,8 @@ package com.talentradar.user_service.repository;
 import com.talentradar.user_service.model.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserSessionRepository extends JpaRepository<Session, Long> {
-    //TODO: retrieve or find sessions By userId and session is active
+    Optional<Session> findBySessionId(String sessionId);
 }

--- a/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
@@ -4,7 +4,8 @@ import com.talentradar.user_service.model.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UserSessionRepository extends JpaRepository<Session, Long> {
+public interface UserSessionRepository extends JpaRepository<Session, UUID> {
     Optional<Session> findBySessionId(String sessionId);
 }

--- a/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
@@ -1,6 +1,8 @@
 package com.talentradar.user_service.repository;
 
 import com.talentradar.user_service.model.Session;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,5 @@ import java.util.UUID;
 
 public interface UserSessionRepository extends JpaRepository<Session, UUID> {
     Optional<Session> findBySessionId(String sessionId);
+    Page<Session> findAllByIsActiveTrue(Pageable pageable);
 }

--- a/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/UserSessionRepository.java
@@ -3,6 +3,6 @@ package com.talentradar.user_service.repository;
 import com.talentradar.user_service.model.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SessionRepository extends JpaRepository<Session, Long> {
+public interface UserSessionRepository extends JpaRepository<Session, Long> {
     //TODO: retrieve or find sessions By userId and session is active
 }

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -19,9 +19,9 @@ public class SessionService {
     private final UserSessionRepository userSessionRepository;
     private final SessionMapper sessionMapper;
 
-public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
-    Page<Session> sessionPage = this.userSessionRepository.findAll(pageable);
-    logger.info("Admin fetched active sessions");
-    return sessionPage.map(sessionMapper::toDto);
-}
+    public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
+        Page<Session> sessionPage = this.userSessionRepository.findAll(pageable);
+        logger.info("Admin fetched active sessions");
+        return sessionPage.map(sessionMapper::toDto);
+    }
 }

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -1,0 +1,23 @@
+package com.talentradar.user_service.service;
+
+import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.mapper.SessionMapper;
+import com.talentradar.user_service.model.Session;
+import com.talentradar.user_service.repository.UserSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+    private final UserSessionRepository userSessionRepository;
+    private final SessionMapper sessionMapper;
+
+public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
+    Page<Session> sessionPage = this.userSessionRepository.findAll(pageable);
+
+    return sessionPage.map(sessionMapper::toDto);
+}
+}

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -1,6 +1,7 @@
 package com.talentradar.user_service.service;
 
 import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.listener.AuthenticationSuccessListener;
 import com.talentradar.user_service.mapper.SessionMapper;
 import com.talentradar.user_service.model.Session;
 import com.talentradar.user_service.repository.UserSessionRepository;
@@ -8,16 +9,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 @RequiredArgsConstructor
 public class SessionService {
+    private static final Logger logger = LoggerFactory.getLogger(SessionService.class);
     private final UserSessionRepository userSessionRepository;
     private final SessionMapper sessionMapper;
 
 public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
     Page<Session> sessionPage = this.userSessionRepository.findAll(pageable);
-
+    logger.info("Admin fetched active sessions");
     return sessionPage.map(sessionMapper::toDto);
 }
 }

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -20,7 +20,7 @@ public class SessionService {
     private final SessionMapper sessionMapper;
 
     public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
-        Page<Session> sessionPage = this.userSessionRepository.findAll(pageable);
+        Page<Session> sessionPage = this.userSessionRepository.findAllByIsActiveTrue(pageable);
         logger.info("Admin fetched active sessions");
         return sessionPage.map(sessionMapper::toDto);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,6 @@ spring:
     config:
       uri: ${SPRING_CLOUD_CONFIG_URI}
 
+
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,4 @@ spring:
   cloud:
     config:
       uri: ${SPRING_CLOUD_CONFIG_URI}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
   cloud:
     config:
       uri: ${SPRING_CLOUD_CONFIG_URI}
+  session:
+    store-type: redis
+    timeout: 30m
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOSTNAME}
+      port: ${REDIS_PORT}
 
 
 

--- a/src/test/java/com/talentradar/user_service/SessionServiceTests.java
+++ b/src/test/java/com/talentradar/user_service/SessionServiceTests.java
@@ -1,0 +1,62 @@
+package com.talentradar.user_service;
+import com.talentradar.user_service.dto.SessionResponseDto;
+import com.talentradar.user_service.mapper.SessionMapper;
+import com.talentradar.user_service.model.Session;
+import com.talentradar.user_service.repository.UserSessionRepository;
+import com.talentradar.user_service.service.SessionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class SessionServiceTests {
+    @Mock
+    private UserSessionRepository sessionRepository;
+
+    @Mock
+    private SessionMapper sessionMapper;
+
+    @InjectMocks
+    private SessionService sessionService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this); // initialize mocks
+    }
+
+    @Test
+    void testGetActiveSessions_returnsMappedDtos() {
+        // Given
+        Session session = Session.builder()
+                .id(UUID.randomUUID())
+                .sessionId("abc123")
+                .ipAddress("192.168.0.1")
+                .deviceInfo("Chrome")
+                .createdAt(LocalDateTime.now())
+                .isActive(true)
+                .build();
+
+        SessionResponseDto responseDto = new SessionResponseDto();
+        responseDto.setSessionId("abc123");
+
+        Page<Session> sessionPage = new PageImpl<>(List.of(session));
+        when(sessionRepository.findAll(any(Pageable.class))).thenReturn(sessionPage);
+        when(sessionMapper.toDto(session)).thenReturn(responseDto);
+        // When
+        Page<SessionResponseDto> result = sessionService.getActiveSessions(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.getContent().get(0).getSessionId()).isEqualTo("abc123");
+
+        verify(sessionRepository).findAll(any(Pageable.class));
+        verify(sessionMapper).toDto(session);
+    }
+}


### PR DESCRIPTION
## 🛡️ Session Management - Admin Access to Active Sessions

### 🎫 Jira Ticket  
[🔗 TRA-109: Allow only admin to view active user sessions](https://amali-tech.atlassian.net/browse/TRA-15)  

---

### ✅ What’s covered in this PR
- Fetch active sessions with pagination
- Added **admin-only access control** for fetching the sessions
- Integrated **MapStruct** to map `Session` entity to `SessionDto` with embedded `UserSummaryDto`
- Added **Swagger API documentation** for the endpoint
- Implemented **logging** to track access to session data
- Wrote **unit tests** for the service method using **Mockito**

---

### 📌 Next steps (planned)
- Add filtering (e.g. by IP/device/user)
- Expose session retrieval via user profile (e.g. "Where am I logged in?")
- Include logout tracking (invalidate Redis + update Postgres)

---

### 🛠 Technical details
- Role-based access control is handled by checking `X-User-Role` header  
  *(to be later migrated to Spring Security context for robustness)*
- `SessionDto` includes full session metadata and a nested `UserSummaryDto` (id, email + fullname only)
- MapStruct is used for clean, type-safe DTO conversion
- Swagger annotations added for better API documentation
- Logging added in service layer using `LoggerFactory`
- Test class `SessionServiceTest` mocks repository + mapper to verify logic

---

### 🧪 Testing
- ✅ Unit test for service method that:
  - Mocks repository and mapper
  - Verifies only active sessions are returned
- ✅ Manual test via Postman to verify:
  - Endpoint restricts access to admins
  - Correct JSON response structure (including nested user info)
  - Swagger UI displays and documents the endpoint correctly

---

### 🚀 Summary  
> This update allows only Admins to view or fetch the active sessions,  
> introduces clean DTOs via MapStruct, and improves API visibility & reliability.  
