### PR TITLE
feat(tra-162): implement get all roles by admin

### DIFF
--- a/src/main/java/com/talentradar/user_service/config/SecurityConfig.java
+++ b/src/main/java/com/talentradar/user_service/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,6 +24,7 @@ import com.talentradar.user_service.security.HeaderAuthenticationFilter;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
     private final CustomUserDetailsService userDetailsService;
     private final CustomAuthEntryPoint authEntryPoint;

--- a/src/main/java/com/talentradar/user_service/controller/RoleController.java
+++ b/src/main/java/com/talentradar/user_service/controller/RoleController.java
@@ -1,0 +1,27 @@
+package com.talentradar.user_service.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.talentradar.user_service.dto.ResponseDto;
+import com.talentradar.user_service.service.RoleService;
+
+@RestController
+@RequestMapping("/api/v1/roles")
+public class RoleController {
+    private final RoleService roleService;
+
+    public RoleController(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResponseDto> getAllRoles() {
+        ResponseDto responseDto = roleService.getAllRoles();
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/talentradar/user_service/dto/RoleDto.java
+++ b/src/main/java/com/talentradar/user_service/dto/RoleDto.java
@@ -1,0 +1,33 @@
+package com.talentradar.user_service.dto;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.talentradar.user_service.model.Role;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RoleDto {
+    private UUID id;
+    private String roleName;
+
+    public static List<RoleDto> fromRole(List<Role> roles) {
+        return roles.stream()
+                .map(role -> RoleDto.builder()
+                        .id(role.getId())
+                        .roleName(role.getRoleName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/talentradar/user_service/service/RoleService.java
+++ b/src/main/java/com/talentradar/user_service/service/RoleService.java
@@ -1,0 +1,35 @@
+package com.talentradar.user_service.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.talentradar.user_service.dto.ResponseDto;
+import com.talentradar.user_service.dto.RoleDto;
+import com.talentradar.user_service.model.Role;
+import com.talentradar.user_service.repository.RoleRepository;
+
+@Service
+public class RoleService {
+    private final RoleRepository roleRepository;
+
+    public RoleService(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    // Get All roles
+    public ResponseDto getAllRoles() {
+        List<Role> roles = roleRepository.findAll();
+        List<RoleDto> roleDtos = RoleDto.fromRole(roles);
+
+        ResponseDto responseDto = new ResponseDto();
+        responseDto.setMessage("Roles retrieved successfully");
+        responseDto.setData(roleDtos);
+        responseDto.setStatus(true);
+        responseDto.setErrors(null);
+        responseDto.setData(Map.of("roles", roleDtos));
+
+        return responseDto;
+    }
+}


### PR DESCRIPTION
## Description
This pull request introduces role-based access control (RBAC) and enhances security configurations in the `user_service` module. Key changes include enabling method-level security, adding a new `RoleController` for managing roles, creating a `RoleDto` for data transfer, and implementing a `RoleService` for role-related business logic.

## 🔗 Jira Ticket
<!-- Replace with your Jira ticket ID -->
Closes [TRA-162](https://amali-tech.atlassian.net/browse/TRA-162)

### Security Enhancements:
* `@EnableMethodSecurity` annotation to the class and importing the corresponding configuration.

### Role Management:
* Added a new controller to handle role-related API endpoints. Includes a `GET /api/v1/roles` endpoint secured with `@PreAuthorize("hasRole('ADMIN')")` to retrieve all roles.
* Introduced a data transfer object to encapsulate role information and added a utility method for converting `Role` entities to `RoleDto`.
* Implemented a service class for business logic related to roles, including a method to fetch all roles and return them in a structured `ResponseDto`.