### PR TITLE
feat(tra166): setup kafka to fire events when user is created and updated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7-alpine
-    container_name: user-session-service-redis
+    image: redis:7.2
+    container_name: redis-server
     ports:
-      - ${REDIS_PORT}:${REDIS_PORT}
+      - '6379:6379'

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,16 @@
             <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
+
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>3.2.3</version> 
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
         
         <!-- Jakarta Mail API for sending emails -->
         <dependency>

--- a/src/main/java/com/talentradar/user_service/config/KafkaProducerConfig.java
+++ b/src/main/java/com/talentradar/user_service/config/KafkaProducerConfig.java
@@ -1,0 +1,40 @@
+package com.talentradar.user_service.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import com.talentradar.user_service.dto.UserCreatedEvent;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // Kafka
+    @Bean
+    ProducerFactory<String, UserCreatedEvent> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                JsonSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    KafkaTemplate<String, UserCreatedEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/java/com/talentradar/user_service/dto/EventRole.java
+++ b/src/main/java/com/talentradar/user_service/dto/EventRole.java
@@ -1,0 +1,6 @@
+package com.talentradar.user_service.dto;
+
+public enum EventRole {
+    DEVELOPER, MANAGER
+
+}

--- a/src/main/java/com/talentradar/user_service/dto/EventType.java
+++ b/src/main/java/com/talentradar/user_service/dto/EventType.java
@@ -1,0 +1,5 @@
+package com.talentradar.user_service.dto;
+
+public enum EventType {
+    USER_CREATED, USER_UPDATED, USER_DELETED
+}

--- a/src/main/java/com/talentradar/user_service/dto/UserCreatedEvent.java
+++ b/src/main/java/com/talentradar/user_service/dto/UserCreatedEvent.java
@@ -1,0 +1,30 @@
+package com.talentradar.user_service.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCreatedEvent implements Serializable {
+    private EventType eventType; // USER_CREATED, USER_UPDATED, USER_DELETED
+    private UUID userId;
+    private UUID managerId;
+    private String fullName;
+    private String username;
+    private String email;
+    private EventRole role; // DEVELOPER, MANAGER
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+    private String eventId;
+    private String source;
+}

--- a/src/main/java/com/talentradar/user_service/repository/UserRepository.java
+++ b/src/main/java/com/talentradar/user_service/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUsername(String username);
 
     Page<User> findByRole(Role role, PageRequest pageRequest);
+
+    List<User> findByRole(Role role);
 }

--- a/src/main/java/com/talentradar/user_service/service/KafkaService.java
+++ b/src/main/java/com/talentradar/user_service/service/KafkaService.java
@@ -1,0 +1,31 @@
+package com.talentradar.user_service.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.talentradar.user_service.dto.UserCreatedEvent;
+
+@Service
+public class KafkaService {
+    private final KafkaTemplate<String, UserCreatedEvent> kafkaTemplate;
+
+    public KafkaService(KafkaTemplate<String, UserCreatedEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Value("${topic.user-created}")
+    private String userCreatedTopic;
+
+    @Value("${topic.user-updated}")
+    private String userUpdatedTopic;
+
+    public void sendUserCreatedEvent(UserCreatedEvent userCreatedEvent) {
+        kafkaTemplate.send(userCreatedTopic, userCreatedEvent);
+    }
+
+    public void sendUserUpdatedEvent(UserCreatedEvent userUpdatedEvent) {
+        kafkaTemplate.send(userUpdatedTopic, userUpdatedEvent);
+    }
+
+}


### PR DESCRIPTION
## Description
This pull request introduces Kafka integration for event-driven communication within the `user_service` module, adds support for new event types and roles, and includes updates to the repository and service layers to handle these changes. The most important changes include adding Kafka configuration, creating DTOs for events, implementing event publishing in the service layer, and updating the repository to support new queries.

## 🔗 Jira Ticket
<!-- Replace with your Jira ticket ID -->
Closes [TRA-166](https://amali-tech.atlassian.net/browse/TRA-166)

### Kafka Integration:

* Added Kafka configuration to enable event publishing, including producer factory and Kafka template beans.
* Implemented a service for sending Kafka events for user creation and updates.

### Event DTOs:

*  Created a DTO to represent user-related events, including fields for event type, user details, role, and timestamp.
*  Added an enumeration to define event types such as `USER_CREATED`, `USER_UPDATED`, and `USER_DELETED`.
* Added an enumeration to define roles such as `DEVELOPER` and `MANAGER`.

### Service Layer Enhancements:

* Integrated Kafka event publishing into user-related operations, including firing events for user creation and updates. Added logic to handle `DEVELOPER` and `MANAGER` roles during event creation.

### Repository Updates:

* Added a new method `findByRole(Role role)` to fetch users by their role without pagination.

### Miscellaneous Updates:

* Updated Redis service configuration to use `redis:7.2` and changed port mapping to `6379:6379`.
* Added dependencies for Kafka and Jackson Databind to support event serialization and communication.