### PR TITLE
Custom Pagination Response Format

### DIFF
--- a/src/main/java/com/talentradar/user_service/controller/AuthController.java
+++ b/src/main/java/com/talentradar/user_service/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
 
     private final AuthenticationService authService;
     private final UserService userService;
-    
+
     @PostMapping("/login")
     public ResponseEntity<Object> signin(@RequestBody LoginRequestDto loginRequest) {
         Map<String, Object> loginResponse = authService.login(loginRequest);

--- a/src/main/java/com/talentradar/user_service/controller/SessionController.java
+++ b/src/main/java/com/talentradar/user_service/controller/SessionController.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service.controller;
 
+import com.talentradar.user_service.dto.CustomPageResponse;
 import com.talentradar.user_service.dto.ResponseDto;
 import com.talentradar.user_service.dto.SessionResponseDto;
 import com.talentradar.user_service.service.SessionService;
@@ -32,7 +33,7 @@ public class SessionController {
     @PreAuthorize("hasRole('Admin')")
     public ResponseEntity<ResponseDto> viewActiveSession(Pageable pageable){
         logger.info("Admin requests fetched active session list");
-        Page<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);
+        CustomPageResponse<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);
         ResponseDto response = ResponseDto.builder()
                 .status(true)
                 .message("Fetch session list")
@@ -69,7 +70,7 @@ public class SessionController {
                                                      @RequestParam(required = false) String date,
                                                      Pageable pageable){
         logger.info("Admin requests filter session list");
-        Page<SessionResponseDto> sessionsList = sessionService.filterSessions(userId, date, pageable);
+        CustomPageResponse<SessionResponseDto> sessionsList = sessionService.filterSessions(userId, date, pageable);
         ResponseDto response = ResponseDto.builder()
                 .status(true)
                 .message("Filter session list")

--- a/src/main/java/com/talentradar/user_service/dto/CustomPageResponse.java
+++ b/src/main/java/com/talentradar/user_service/dto/CustomPageResponse.java
@@ -1,0 +1,22 @@
+package com.talentradar.user_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CustomPageResponse <T>{
+    private List<T> items;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/com/talentradar/user_service/listener/AuthenticationSuccessListener.java
@@ -74,7 +74,7 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
             logger.info("Update user {} session", email);
             // update fields
             existing.setIpAddress(ip);
-            existing.setDeviceInfo(userAgent);
+            existing.setDeviceInfo(deviceInfo);
             existing.setActive(true);
             existing.setCreatedAt(LocalDateTime.now());
             userSessionRepository.save(existing);

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service.service;
 
+import com.talentradar.user_service.dto.CustomPageResponse;
 import com.talentradar.user_service.dto.SessionResponseDto;
 import com.talentradar.user_service.dto.UserNotFoundException;
 import com.talentradar.user_service.exception.InvalidDateFormatException;
@@ -31,11 +32,21 @@ public class SessionService {
     private final SessionMapper sessionMapper;
     private final UserRepository userRepository;
 
-    public Page<SessionResponseDto> getActiveSessions(Pageable pageable) {
+    public CustomPageResponse<SessionResponseDto> getActiveSessions(Pageable pageable) {
         Page<Session> sessionPage = this.userSessionRepository
                 .findAllByIsActiveTrue(pageable);
         logger.info("Admin fetched active sessions");
-        return sessionPage.map(sessionMapper::toDto);
+        Page<SessionResponseDto> sessions = sessionPage.map(sessionMapper::toDto);
+
+        return CustomPageResponse.<SessionResponseDto>builder()
+                .items(sessions.getContent())
+                .page(sessions.getNumber())
+                .size(sessions.getSize())
+                .totalElements(sessions.getTotalElements())
+                .totalPages(sessions.getTotalPages())
+                .hasNext(sessions.hasNext())
+                .hasPrevious(sessions.hasPrevious())
+                .build();
     }
 
     @Transactional
@@ -51,7 +62,7 @@ public class SessionService {
         this.userSessionRepository.deleteBySessionId(sessionId); // this session data in DB
         logger.info("Admin revoked session with ID: {}", sessionId);
     }
-    public Page<SessionResponseDto> filterSessions(
+    public CustomPageResponse<SessionResponseDto> filterSessions(
             UUID userId,
             String dateString,
             Pageable pageable
@@ -79,10 +90,19 @@ public class SessionService {
 
         // No filter, return all
         logger.info("Admin fetched with no filter");
-        return userSessionRepository
+        Page<SessionResponseDto> sessions =  userSessionRepository
                 .findAll(pageable)
                 .map(sessionMapper::toDto);
 
+        return CustomPageResponse.<SessionResponseDto>builder()
+                .items(sessions.getContent())
+                .page(sessions.getNumber())
+                .size(sessions.getSize())
+                .totalElements(sessions.getTotalElements())
+                .totalPages(sessions.getTotalPages())
+                .hasNext(sessions.hasNext())
+                .hasPrevious(sessions.hasPrevious())
+                .build();
     }
 
     private boolean isUserIdValid(UUID userId){
@@ -104,30 +124,61 @@ public class SessionService {
             }
     }
 
-    private Page<SessionResponseDto> filterByUserIdAndDate(UUID userId, LocalDate date,
+    private CustomPageResponse<SessionResponseDto> filterByUserIdAndDate(UUID userId, LocalDate date,
                                                              Pageable pageable){
         logger.info("Admin filtered by userId and date");
 
         LocalDateTime start = date.atStartOfDay();
         LocalDateTime end = date.atTime(LocalTime.MAX);
-        return userSessionRepository
+
+        Page<SessionResponseDto> sessions = userSessionRepository
                 .findByUserIdAndCreatedAtBetween(userId, start, end, pageable)
                 .map(sessionMapper::toDto);
+
+        return CustomPageResponse.<SessionResponseDto>builder()
+                .items(sessions.getContent())
+                .page(sessions.getNumber())
+                .size(sessions.getSize())
+                .totalElements(sessions.getTotalElements())
+                .totalPages(sessions.getTotalPages())
+                .hasNext(sessions.hasNext())
+                .hasPrevious(sessions.hasPrevious())
+                .build();
     }
 
-    private Page<SessionResponseDto> filterByOnlyDate(LocalDate date, Pageable pageable){
+    private CustomPageResponse<SessionResponseDto> filterByOnlyDate(LocalDate date, Pageable pageable){
         logger.info("Admin filtered only by date");
         LocalDateTime start = date.atStartOfDay();
         LocalDateTime end = date.atTime(LocalTime.MAX);
-        return userSessionRepository
+        Page<SessionResponseDto> sessions =  userSessionRepository
                 .findByCreatedAtBetween(start, end, pageable)
                 .map(sessionMapper::toDto);
+
+        return CustomPageResponse.<SessionResponseDto>builder()
+                .items(sessions.getContent())
+                .page(sessions.getNumber())
+                .size(sessions.getSize())
+                .totalElements(sessions.getTotalElements())
+                .totalPages(sessions.getTotalPages())
+                .hasNext(sessions.hasNext())
+                .hasPrevious(sessions.hasPrevious())
+                .build();
     }
 
-    private Page<SessionResponseDto> filterByOnlyUserId(UUID userId, Pageable pageable){
+    private CustomPageResponse<SessionResponseDto> filterByOnlyUserId(UUID userId, Pageable pageable){
         logger.info("Admin filtered only by userId");
-        return userSessionRepository
+        Page<SessionResponseDto> sessions = userSessionRepository
                 .findAllByUserId(userId, pageable)
                 .map(sessionMapper::toDto);
+
+        return CustomPageResponse.<SessionResponseDto>builder()
+                .items(sessions.getContent())
+                .page(sessions.getNumber())
+                .size(sessions.getSize())
+                .totalElements(sessions.getTotalElements())
+                .totalPages(sessions.getTotalPages())
+                .hasNext(sessions.hasNext())
+                .hasPrevious(sessions.hasPrevious())
+                .build();
     }
 }

--- a/src/test/java/com/talentradar/user_service/SessionServiceFilterTest.java
+++ b/src/test/java/com/talentradar/user_service/SessionServiceFilterTest.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service;
 
+import com.talentradar.user_service.dto.CustomPageResponse;
 import com.talentradar.user_service.dto.SessionResponseDto;
 import com.talentradar.user_service.dto.UserNotFoundException;
 import com.talentradar.user_service.exception.InvalidDateFormatException;
@@ -49,9 +50,9 @@ public class SessionServiceFilterTest {
         when(userSessionRepository.findAllByUserId(userId, pageable)).thenReturn(new PageImpl<>(sessions));
         when(sessionMapper.toDto(any())).thenReturn(mock(SessionResponseDto.class));
 
-        Page<SessionResponseDto> result = sessionService.filterSessions(userId, null, pageable);
+        CustomPageResponse<SessionResponseDto> result = sessionService.filterSessions(userId, null, pageable);
 
-        assertEquals(1, result.getContent().size());
+        assertEquals(1, result.getItems().size());
         verify(userSessionRepository).findAllByUserId(userId, pageable);
     }
 
@@ -66,9 +67,9 @@ public class SessionServiceFilterTest {
         when(userSessionRepository.findByCreatedAtBetween(start, end, pageable)).thenReturn(new PageImpl<>(sessions));
         when(sessionMapper.toDto(any())).thenReturn(mock(SessionResponseDto.class));
 
-        Page<SessionResponseDto> result = sessionService.filterSessions(null, dateStr, pageable);
+        CustomPageResponse<SessionResponseDto> result = sessionService.filterSessions(null, dateStr, pageable);
 
-        assertEquals(1, result.getContent().size());
+        assertEquals(1, result.getItems().size());
         verify(userSessionRepository).findByCreatedAtBetween(start, end, pageable);
     }
 
@@ -85,9 +86,9 @@ public class SessionServiceFilterTest {
                 .thenReturn(new PageImpl<>(sessions));
         when(sessionMapper.toDto(any())).thenReturn(mock(SessionResponseDto.class));
 
-        Page<SessionResponseDto> result = sessionService.filterSessions(userId, dateStr, pageable);
+        CustomPageResponse<SessionResponseDto> result = sessionService.filterSessions(userId, dateStr, pageable);
 
-        assertEquals(1, result.getContent().size());
+        assertEquals(1, result.getItems().size());
         verify(userSessionRepository).findByUserIdAndCreatedAtBetween(userId, start, end, pageable);
     }
 
@@ -97,9 +98,9 @@ public class SessionServiceFilterTest {
         when(userSessionRepository.findAll(pageable)).thenReturn(new PageImpl<>(sessions));
         when(sessionMapper.toDto(any())).thenReturn(mock(SessionResponseDto.class));
 
-        Page<SessionResponseDto> result = sessionService.filterSessions(null, null, pageable);
+        CustomPageResponse<SessionResponseDto> result = sessionService.filterSessions(null, null, pageable);
 
-        assertEquals(1, result.getContent().size());
+        assertEquals(1, result.getItems().size());
         verify(userSessionRepository).findAll(pageable);
     }
 

--- a/src/test/java/com/talentradar/user_service/SessionServiceRevokeTests.java
+++ b/src/test/java/com/talentradar/user_service/SessionServiceRevokeTests.java
@@ -1,5 +1,6 @@
 package com.talentradar.user_service;
 
+import com.talentradar.user_service.dto.CustomPageResponse;
 import com.talentradar.user_service.dto.SessionResponseDto;
 import com.talentradar.user_service.exception.SessionNotFoundException;
 import com.talentradar.user_service.mapper.SessionMapper;
@@ -55,12 +56,12 @@ class SessionServiceRevokeTests {
         when(sessionMapper.toDto(session)).thenReturn(responseDto);
 
         // When
-        Page<SessionResponseDto> result = sessionService.getActiveSessions(PageRequest.of(0, 10));
+        CustomPageResponse<SessionResponseDto> result = sessionService.getActiveSessions(PageRequest.of(0, 10));
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getSessionId()).isEqualTo("abc123");
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getSessionId()).isEqualTo("abc123");
 
         // match the method you mocked above
         verify(userSessionRepository).findAllByIsActiveTrue(any(Pageable.class));


### PR DESCRIPTION
## 🚀 Feature: Custom Pagination Response Format

### 📌 Summary

This PR customizes the default Spring Data pagination response to match the format expected by the frontend team. Specifically:

- Renamed the `content` field to `items`
- Simplified pagination metadata to include:
  - `page`
  - `size`
  - `totalElements`
  - `totalPages`
  - `hasNext`
  - `hasPrevious`

### ✅ What Was Done

- Created `CustomPageResponse<T>` DTO to wrap paginated data.
- Added a static factory method (`fromPage`) to convert `Page<T>` to `CustomPageResponse<T>`.
- Updated controller(s) to return `CustomPageResponse` instead of the default `Page<T>` serialization.

### 📥 Sample Response Format

```json
{
  "items": [
    {
      "id": "...",
      "sessionId": "...",
      "createdAt": "...",
      "user": {
        "id": "...",
        "fullName": "...",
        "email": "..."
      },
      "active": true
    }
  ],
  "page": 0,
  "size": 20,
  "totalElements": 3,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false
}
