### PR TITLE
Update service session to not revoke header cookie

### DIFF
--- a/src/main/java/com/talentradar/user_service/controller/SessionController.java
+++ b/src/main/java/com/talentradar/user_service/controller/SessionController.java
@@ -11,7 +11,6 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +29,7 @@ public class SessionController {
     @GetMapping(name = "fetchActiveSessions", path = "/sessions")
     @Operation(summary = "Fetch all active session",
             description = "This end point allows only admin to view all of the active session")
-    @PreAuthorize("hasRole('Admin')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<ResponseDto> viewActiveSession(Pageable pageable){
         logger.info("Admin requests fetched active session list");
         CustomPageResponse<SessionResponseDto> sessionsList = sessionService.getActiveSessions(pageable);
@@ -43,14 +42,13 @@ public class SessionController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping(name = "revokeASingleSession", path = "/sessions/{sessionId}")
     @Operation(summary = "Delete a single session",
             description = "This end point allows only admin to delete/revoke a session using its id")
-    public ResponseEntity<?> deleteSession(@PathVariable String sessionId, HttpServletRequest request){
+    public ResponseEntity<?> deleteSession(@PathVariable String sessionId){
         logger.info("Admin requests revoke session");
-        HttpSession session = request.getSession(false); // get current session
-        this.sessionService.revokeSessionById(sessionId, session);
+        this.sessionService.revokeSessionById(sessionId);
         String message = String.format("The session with id '%s' revoked successfully", sessionId);
         ResponseDto response = ResponseDto.builder()
                 .status(true)
@@ -62,7 +60,7 @@ public class SessionController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping(name = "filterSessions", path = "/sessions/filter")
     @Operation(summary = "Filter all active session",
             description = "This end point allows only admin to filter by userId and date")

--- a/src/main/java/com/talentradar/user_service/service/SessionService.java
+++ b/src/main/java/com/talentradar/user_service/service/SessionService.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.session.SessionRepository;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ public class SessionService {
     private final UserSessionRepository userSessionRepository;
     private final SessionMapper sessionMapper;
     private final UserRepository userRepository;
+    private final SessionRepository sessionRepository;
 
     public CustomPageResponse<SessionResponseDto> getActiveSessions(Pageable pageable) {
         Page<Session> sessionPage = this.userSessionRepository
@@ -50,7 +52,7 @@ public class SessionService {
     }
 
     @Transactional
-    public void revokeSessionById(String sessionId, HttpSession sessionRequest) {
+    public void revokeSessionById(String sessionId) {
         if(this.userSessionRepository.findBySessionId(sessionId).isEmpty()){
             throw new SessionNotFoundException(
                     String.format("The session with id '%s' does not exist",
@@ -58,7 +60,7 @@ public class SessionService {
 
         }
 
-        sessionRequest.invalidate(); // this deletes session from Redis
+        sessionRepository.deleteById(sessionId); //delete from redis
         this.userSessionRepository.deleteBySessionId(sessionId); // this session data in DB
         logger.info("Admin revoked session with ID: {}", sessionId);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,14 +6,6 @@ spring:
   cloud:
     config:
       uri: ${SPRING_CLOUD_CONFIG_URI}
-  session:
-    store-type: redis
-    timeout: 30m
-
-  data:
-    redis:
-      host: ${REDIS_HOSTNAME}
-      port: ${REDIS_PORT}
 
   profiles:
     active: prod

--- a/src/test/java/com/talentradar/user_service/SessionServiceFilterTest.java
+++ b/src/test/java/com/talentradar/user_service/SessionServiceFilterTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
+import org.springframework.session.SessionRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,7 +38,8 @@ public class SessionServiceFilterTest {
         userSessionRepository = mock(UserSessionRepository.class);
         sessionMapper = mock(SessionMapper.class);
         userRepository = mock(UserRepository.class);
-        sessionService = new SessionService(userSessionRepository, sessionMapper, userRepository);
+        SessionRepository redisSessionRepository = mock(SessionRepository.class);
+        sessionService = new SessionService(userSessionRepository, sessionMapper, userRepository, redisSessionRepository);
         pageable = PageRequest.of(0, 10);
         userId = UUID.randomUUID();
     }

--- a/src/test/java/com/talentradar/user_service/SessionServiceRevokeTests.java
+++ b/src/test/java/com/talentradar/user_service/SessionServiceRevokeTests.java
@@ -7,13 +7,13 @@ import com.talentradar.user_service.mapper.SessionMapper;
 import com.talentradar.user_service.model.Session;
 import com.talentradar.user_service.repository.UserSessionRepository;
 import com.talentradar.user_service.service.SessionService;
-import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
+import org.springframework.session.SessionRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,8 +28,12 @@ class SessionServiceRevokeTests {
 
     @Mock
     private UserSessionRepository userSessionRepository;
+
     @Mock
-    SessionMapper sessionMapper;
+    private SessionMapper sessionMapper;
+
+    @Mock
+    private SessionRepository<?> sessionRepository;
 
     @InjectMocks
     private SessionService sessionService;
@@ -51,8 +55,7 @@ class SessionServiceRevokeTests {
 
         Page<Session> sessionPage = new PageImpl<>(List.of(session));
 
-        // match the actual repository method used in your service
-        when(userSessionRepository.findAllByIsActiveTrue (any(Pageable.class))).thenReturn(sessionPage);
+        when(userSessionRepository.findAllByIsActiveTrue(any(Pageable.class))).thenReturn(sessionPage);
         when(sessionMapper.toDto(session)).thenReturn(responseDto);
 
         // When
@@ -63,7 +66,6 @@ class SessionServiceRevokeTests {
         assertThat(result.getItems()).hasSize(1);
         assertThat(result.getItems().get(0).getSessionId()).isEqualTo("abc123");
 
-        // match the method you mocked above
         verify(userSessionRepository).findAllByIsActiveTrue(any(Pageable.class));
         verify(sessionMapper).toDto(session);
     }
@@ -72,31 +74,31 @@ class SessionServiceRevokeTests {
     void testRevokeSessionById_whenSessionExists_shouldInvalidateAndDelete() {
         // Given
         String sessionId = "abc-123";
-        Session session = new Session(); // session Entity
-        HttpSession httpSession = mock(HttpSession.class);
+        Session session = new Session(); // dummy session
 
         when(userSessionRepository.findBySessionId(sessionId)).thenReturn(Optional.of(session));
+
         // When
-        sessionService.revokeSessionById(sessionId, httpSession);
+        sessionService.revokeSessionById(sessionId);
 
         // Then
         verify(userSessionRepository).findBySessionId(sessionId);
-        verify(httpSession).invalidate();
+        verify(sessionRepository).deleteById(sessionId); //using class-level mock
         verify(userSessionRepository).deleteBySessionId(sessionId);
     }
 
     @Test
     void testRevokeSessionById_whenSessionNotFound_shouldThrowException() {
+        // Given
         String sessionId = "not-found";
-        HttpSession httpSession = mock(HttpSession.class);
-
         when(userSessionRepository.findBySessionId(sessionId)).thenReturn(Optional.empty());
 
+        // When / Then
         Assertions.assertThrows(SessionNotFoundException.class, () -> {
-            sessionService.revokeSessionById(sessionId, httpSession);
+            sessionService.revokeSessionById(sessionId);
         });
 
-        verify(httpSession, never()).invalidate();
+        verify(sessionRepository, never()).deleteById(any()); // no Redis call
         verify(userSessionRepository, never()).deleteBySessionId(any());
     }
 }


### PR DESCRIPTION
The changes applied to the revoking session do not rely on the current session stored in the header. 