### PR TITLE
Add Comprehensive Automated Test Report Generation and Deployment

### DIFF
--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           allure_results: allure-results
           allure_history: allure-history
+          subfolder: allure
           keep_reports: 1
 
       - name: Copy generated allure report and history

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -104,14 +104,14 @@ jobs:
         if: always()
         with:
           allure_results: allure-results
-          allure_history: allure-history
+          allure_history: allure
           subfolder: allure
           keep_reports: 1
 
       - name: Copy generated allure report and history
         run: |
           mkdir -p publish-reports/allure
-          cp -r allure-history/* publish-reports/allure/
+          cp -r allure/* publish-reports/allure/
 
       - name: Deploy to GitHub Pages
         if: always()

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -1,16 +1,11 @@
-name: Allure & Coverage Report CI
-
+name: Build, JaCoCo, Allure, and Deploy Reports
 on:
-  push:
-    branches:
-      - refactor/allure-and-coverage-ci
   pull_request:
     branches:
       - development
       - staging
-
 jobs:
-  test:
+  build-test-reports:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -57,9 +52,9 @@ jobs:
           path: target/site/jacoco/
           retention-days: 1
 
-  publish-allure-and-coverage-reports:
+  deploy-reports:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build-test-reports
     if: always()
 
     steps:

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -3,15 +3,14 @@ name: Allure & Coverage Report CI
 on:
   push:
     branches:
-      - development
-      - staging
+      - refactor/allure-and-coverage-ci
   pull_request:
     branches:
       - development
       - staging
 
 jobs:
-  test-coverage:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -32,11 +31,11 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Run tests and generate coverage
+      - name: Run tests and generate reports
         run: mvn clean verify -f external-pom.xml
         continue-on-error: true
 
-      - name: Upload coverage report
+      - name: Upload coverage badge
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,39 +45,66 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: allure-results
+          name: allure
           path: target/allure-results/
-          retention-days: 3
+          retention-days: 1
 
-  generate-allure-report:
+      - name: Upload JaCoCo results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco
+          path: target/site/jacoco/
+          retention-days: 1
+
+  publish-allure-and-coverage-reports:
     runs-on: ubuntu-latest
-    needs: test-coverage
+    needs: test
     if: always()
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download results
+      - name: Download Allure results
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: allure-results
+          name: allure
           path: allure-results/
 
-      - name: Get Allure history
+      - name: Get published reports history
         uses: actions/checkout@v4
         continue-on-error: true
         with:
           ref: gh-pages
           path: gh-pages
 
+      - name: Download report dashboard HTML into publish-reports
+        run: |
+          mkdir -p publish-reports
+          curl -o publish-reports/index.html https://raw.githubusercontent.com/AmaliTech-Training-Academy/talentradar-qa-rw/refs/heads/report-coverage/reports-index.html
+
+      - name: Inject repo name and build date (UTC+2) into reports dashboard HTML
+        run: |
+          REPO_NAME=$(basename "$GITHUB_REPOSITORY")
+          DATE=$(TZ="Etc/GMT-2" date +"%Y-%m-%d %H:%M UTC+2")
+          sed -i "s|{{REPO_NAME}}|$REPO_NAME|g" publish-reports/index.html
+          sed -i "s|{{BUILD_DATE}}|$DATE|g" publish-reports/index.html
+      
+      - name: Download JaCoCo results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: jacoco
+          path: publish-reports/jacoco/
+
       - name: Generate Allure Report
         uses: simple-elf/allure-report-action@master
         if: always()
         with:
           allure_results: allure-results
-          allure_history: allure-history
+          allure_history: publish-reports/allure
           keep_reports: 1
 
       - name: Deploy to GitHub Pages
@@ -87,5 +113,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: allure-history
+          publish_dir: publish-reports
           force_orphan: true

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -104,8 +104,13 @@ jobs:
         if: always()
         with:
           allure_results: allure-results
-          allure_history: publish-reports/allure
+          allure_history: allure-history
           keep_reports: 1
+
+      - name: Copy generated allure report and history
+        run: |
+          mkdir -p publish-reports/allure
+          cp -r allure-history/* publish-reports/allure/
 
       - name: Deploy to GitHub Pages
         if: always()

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -80,47 +80,45 @@ jobs:
           ref: gh-pages
           path: gh-pages
 
-      - name: Download report dashboard HTML into publish-reports
+      - name: Download report dashboard HTML into publish
         run: |
-          mkdir -p publish-reports
-          curl -o publish-reports/index.html https://raw.githubusercontent.com/AmaliTech-Training-Academy/talentradar-qa-rw/refs/heads/report-coverage/reports-index.html
+          mkdir -p publish
+          curl -o publish/index.html https://raw.githubusercontent.com/AmaliTech-Training-Academy/talentradar-qa-rw/refs/heads/report-coverage/reports-index.html
 
       - name: Inject repo name and build date (UTC+2) into reports dashboard HTML
         run: |
           REPO_NAME=$(basename "$GITHUB_REPOSITORY")
           DATE=$(TZ="Etc/GMT-2" date +"%Y-%m-%d %H:%M UTC+2")
-          sed -i "s|{{REPO_NAME}}|$REPO_NAME|g" publish-reports/index.html
-          sed -i "s|{{BUILD_DATE}}|$DATE|g" publish-reports/index.html
+          sed -i "s|{{REPO_NAME}}|$REPO_NAME|g" publish/index.html
+          sed -i "s|{{BUILD_DATE}}|$DATE|g" publish/index.html
       
       - name: Download JaCoCo results
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: jacoco
-          path: publish-reports/jacoco/
+          path: publish/jacoco/
 
       - name: List available allure cache
         continue-on-error: true
         run: |
-          echo "===== GH-PAGES ALLURE ====="
-          ls -la gh-pages/allure
-          echo "===== ALLURE ====="
-          ls -la allure
           echo "===== ALLURE HISTORY ====="
           ls -la allure-history
+
+      - name: Restore Allure history
+        run: |
+          mkdir -p publish/allure
+          if [ -d gh-pages/allure/last-history ]; then
+            cp -r gh-pages/allure/last-history publish/allure/
+          fi
 
       - name: Generate Allure Report
         uses: simple-elf/allure-report-action@master
         if: always()
         with:
           allure_results: allure-results
-          allure_history: allure-history
+          allure_history: publish/allure
           keep_reports: 1
-
-      - name: Copy generated allure report and history
-        run: |
-          mkdir -p publish-reports/allure
-          cp -r allure-history/* publish-reports/allure/
 
       - name: Deploy to GitHub Pages
         if: always()
@@ -128,5 +126,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: publish-reports
+          publish_dir: publish
           force_orphan: true

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -82,43 +82,34 @@ jobs:
 
       - name: Download report dashboard HTML into publish
         run: |
-          mkdir -p publish
-          curl -o publish/index.html https://raw.githubusercontent.com/AmaliTech-Training-Academy/talentradar-qa-rw/refs/heads/report-coverage/reports-index.html
+          mkdir -p gh-pages-deploy
+          mkdir -p gh-pages-deploy/jacoco
+          mkdir -p gh-pages-deploy/allure
+          curl -o gh-pages-deploy/index.html https://raw.githubusercontent.com/AmaliTech-Training-Academy/talentradar-qa-rw/refs/heads/report-coverage/reports-index.html
 
       - name: Inject repo name and build date (UTC+2) into reports dashboard HTML
         run: |
           REPO_NAME=$(basename "$GITHUB_REPOSITORY")
           DATE=$(TZ="Etc/GMT-2" date +"%Y-%m-%d %H:%M UTC+2")
-          sed -i "s|{{REPO_NAME}}|$REPO_NAME|g" publish/index.html
-          sed -i "s|{{BUILD_DATE}}|$DATE|g" publish/index.html
+          sed -i "s|{{REPO_NAME}}|$REPO_NAME|g" gh-pages-deploy/index.html
+          sed -i "s|{{BUILD_DATE}}|$DATE|g" gh-pages-deploy/index.html
       
       - name: Download JaCoCo results
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: jacoco
-          path: publish/jacoco/
-
-      - name: List available allure cache
-        continue-on-error: true
-        run: |
-          echo "===== ALLURE HISTORY ====="
-          ls -la allure-history
-
-      - name: Restore Allure history
-        run: |
-          mkdir -p publish/allure
-          if [ -d gh-pages/allure/last-history ]; then
-            cp -r gh-pages/allure/last-history publish/allure/
-          fi
+          path: gh-pages-deploy/jacoco/
 
       - name: Generate Allure Report
         uses: simple-elf/allure-report-action@master
         if: always()
         with:
           allure_results: allure-results
-          allure_history: publish/allure
-          keep_reports: 1
+          gh-pages: gh-pages/allure
+          subfolder: allure
+          allure_report: gh-pages-deploy/allure
+          keep_reports: 5
 
       - name: Deploy to GitHub Pages
         if: always()
@@ -126,5 +117,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: publish
+          publish_dir: gh-pages-deploy
           force_orphan: true

--- a/.github/workflows/allure-and-coverage-ci.yml
+++ b/.github/workflows/allure-and-coverage-ci.yml
@@ -99,19 +99,28 @@ jobs:
           name: jacoco
           path: publish-reports/jacoco/
 
+      - name: List available allure cache
+        continue-on-error: true
+        run: |
+          echo "===== GH-PAGES ALLURE ====="
+          ls -la gh-pages/allure
+          echo "===== ALLURE ====="
+          ls -la allure
+          echo "===== ALLURE HISTORY ====="
+          ls -la allure-history
+
       - name: Generate Allure Report
         uses: simple-elf/allure-report-action@master
         if: always()
         with:
           allure_results: allure-results
-          allure_history: allure
-          subfolder: allure
+          allure_history: allure-history
           keep_reports: 1
 
       - name: Copy generated allure report and history
         run: |
           mkdir -p publish-reports/allure
-          cp -r allure/* publish-reports/allure/
+          cp -r allure-history/* publish-reports/allure/
 
       - name: Deploy to GitHub Pages
         if: always()


### PR DESCRIPTION
## 📌 Overview

This PR introduces a new CI workflow that automates the testing, report generation, and publishing of Allure and JaCoCo coverage reports to GitHub Pages. The workflow runs on pull requests targeting `development` and `staging` branches.

## ✅ Key Features

- Test Execution & Reporting
  - Uses Maven to run test suites via an external `pom.xml`
  - Generates:
    - ✔️ Allure test execution report (`target/allure-results`)
    - ✔️ JaCoCo coverage report (`target/site/jacoco`)
  - Uploads both reports as artifacts for later deployment
- Coverage Integration
  - Publish coverage metrics to Coveralls using JaCoCo XML output
- Allure Report Handling
  - Reuses historical test data via `simple-elf/allure-report-action`
  - Maintains the last 5 Allure report versions
  - Automatically increments report versions and updates the Allure dashboard
- Custom Dashboard Deployment
  - Downloads a pre-defined `index.html` dashboard
  - Injects repository name and timestamp dynamically
  - Organizes reports under:
    ```shell
    gh-pages/
    |── index.html
    ├── allure/
    └── jacoco/
    ```
- Publishing
  - Deploys all reports and the dashboard to the `gh-pages` branch
  - Uses `peaceiris/actions-gh-pages` with `force_orphan` to ensure a clean, self-contained branch

## 🧪 Trigger Conditions

This workflow runs:
- On pull requests targeting:
  - development
  - staging

### 📁 Deployed Output (on gh-pages branch)
```shell
gh-pages/
├── index.html           ← Custom report dashboard
├── allure/              ← Versioned Allure reports
│   ├── index.html
│   ├── 1/
│   ├── 2/
│   └── last-history/
└── jacoco/              ← Maven-generated HTML coverage
    └── index.html
```

## 📌 Note

- `force_orphan: true` ensures the `gh-pages` branch only contains reports and does not retain unrelated history.
- This setup is modular and can be extended to include Jest, Cypress, or other test/report types in future iterations.

