### PR TITLE
feat: implement logout feature

### DIFF
--- a/src/main/java/com/talentradar/user_service/controller/AuthController.java
+++ b/src/main/java/com/talentradar/user_service/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import com.talentradar.user_service.dto.CompleteRegistrationRequest;
 import com.talentradar.user_service.dto.InviteUserRequest;
 import com.talentradar.user_service.dto.LoginRequestDto;
+import com.talentradar.user_service.dto.ResponseDto;
 import com.talentradar.user_service.dto.UserResponse;
 import com.talentradar.user_service.exception.InvalidTokenException;
 import com.talentradar.user_service.model.User;
@@ -32,6 +33,26 @@ public class AuthController {
 
     private final AuthenticationService authService;
     private final UserService userService;
+
+    // Logout
+    @GetMapping("/logout")
+    public ResponseEntity<ResponseDto> signout() {
+        // Clear the token cookie by setting it with empty value and immediate
+        // expiration
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, "token=; HttpOnly; Path=/; Max-Age=0; SameSite=None");
+
+        ResponseDto response = ResponseDto.builder()
+                .status(true)
+                .message("Logged out successfully")
+                .errors(null)
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(response);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<Object> signin(@RequestBody LoginRequestDto loginRequest) {


### PR DESCRIPTION
This pull request introduces a new logout functionality in the `AuthController` class of the `user_service` module. The changes include adding a new endpoint for logout and updating imports to support the new functionality.

### Logout functionality:
  - Added a new `@GetMapping("/logout")` endpoint to handle user logout by clearing the token cookie and returning a success response. The response uses the newly introduced `ResponseDto` class.
  - Imported `ResponseDto` to support the structure of the logout response.